### PR TITLE
Fix some bugs for using action 'aormsby/Fork-Sync-With-Upstream-action'

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -24,7 +24,8 @@ jobs:
         upstream_sync_repo: Dimlitter/zju-dailyhealth-autocheck
         upstream_sync_branch: main
         target_sync_branch: main
-        git_pull_args: '-s recursive -Xtheirs'
+        target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+        upstream_pull_args: '-s recursive -Xtheirs'
         
     - name: 'Set python'
       uses: actions/setup-python@v1


### PR DESCRIPTION
Thanks for your PR to my repository, but I found following BUGs and fixed them. You can test it.
- `git_pull_args` is invalid args according to the action repository [aormsby/Fork-Sync-With-Upstream-action](https://github.com/aormsby/Fork-Sync-With-Upstream-action)'s readme.
- `target_repo_token` is required to push data to target repository.

